### PR TITLE
Moved API services and DB onto private subnet

### DIFF
--- a/snoke/snoke.tf
+++ b/snoke/snoke.tf
@@ -34,7 +34,7 @@ resource "aws_iam_role_policy_attachment" "ecs-task-permissions" {
 resource "aws_db_instance" "rds-db" {
   allocated_storage      = 10
   apply_immediately      = true
-  db_name                = "postgres"
+  db_name                = "${var.project_name}_pg_db"
   engine                 = "postgres"
   engine_version         = "14"
   instance_class         = "db.t3.micro"
@@ -49,7 +49,7 @@ resource "aws_db_instance" "rds-db" {
 
 # create parameter group for db
 resource "aws_db_parameter_group" "rds" {
-  name   = var.project_name
+  name   = "${var.project_name}-db-param-group"
   family = "postgres14"
 
   parameter {
@@ -88,11 +88,11 @@ resource "aws_vpc_security_group_egress_rule" "allow-db-to-api" {
 }
 
 resource "aws_db_subnet_group" "rds-postgres" {
-  name       = "${var.project_name}_rdd_subnet_group"
-  subnet_ids = [aws_subnet.private_subnet_a.id, aws_subnet.private_subnet_a.id]
+  name       = "${var.project_name}_rds_subnet_group"
+  subnet_ids = [aws_subnet.private_subnet_a.id, aws_subnet.private_subnet_b.id]
 
   tags = {
-    Name = "My DB subnet group"
+    Name = "RDS-db subnet group"
   }
 }
 

--- a/snoke/snoke.tf
+++ b/snoke/snoke.tf
@@ -118,7 +118,7 @@ resource "aws_security_group" "web_traffic" {
   description = "only allow http and https inbound. allow all outbound"
   vpc_id      = aws_default_vpc.default_vpc.id
   tags = {
-    Name = "internet_facing_alb"
+    Name = "${var.project_name}_internet_facing_alb"
   }
 }
 
@@ -151,7 +151,7 @@ resource "aws_vpc_security_group_egress_rule" "allow_all" {
 
 # API servers security group
 resource "aws_security_group" "api_servers" {
-  name        = "api_sg"
+  name        = "${var.project_name}_api_sg"
   description = "only reachable from lb and db."
   vpc_id      = aws_default_vpc.default_vpc.id
 
@@ -553,6 +553,18 @@ resource "aws_subnet" "private_subnet_b" {
   vpc_id            = aws_default_vpc.default_vpc.id
   availability_zone = "${var.region}b"
 }
+
+#associate private subnets with private route table
+resource "aws_route_table_association" "a" {
+  subnet_id      = aws_subnet.private_subnet_a.id
+  route_table_id = aws_route_table.private.id
+}
+
+resource "aws_route_table_association" "b" {
+  subnet_id      = aws_subnet.private_subnet_b.id
+  route_table_id = aws_route_table.private.id
+}
+
 
 # default public subnets
 resource "aws_default_subnet" "default_subnet_a" {

--- a/snoke/snoke.tf
+++ b/snoke/snoke.tf
@@ -39,6 +39,7 @@ resource "aws_db_instance" "rds-db" {
   engine_version         = "14"
   instance_class         = "db.t3.micro"
   parameter_group_name   = aws_db_parameter_group.rds.name
+  db_subnet_group_name   = aws_db_subnet_group.rds-postgres.id
   vpc_security_group_ids = [aws_security_group.rds.id]
   skip_final_snapshot    = true
   username               = "postgres"
@@ -84,6 +85,15 @@ resource "aws_vpc_security_group_egress_rule" "allow-db-to-api" {
   ip_protocol                  = "tcp"
   to_port                      = 5432
   referenced_security_group_id = aws_security_group.api_servers.id
+}
+
+resource "aws_db_subnet_group" "rds-postgres" {
+  name       = "${var.project_name}_rdd_subnet_group"
+  subnet_ids = [aws_subnet.private_subnet_a.id, aws_subnet.private_subnet_a.id]
+
+  tags = {
+    Name = "My DB subnet group"
+  }
 }
 
 ######################################################################################

--- a/snoke/snoke.tf
+++ b/snoke/snoke.tf
@@ -68,7 +68,7 @@ resource "aws_security_group" "rds" {
 
 # DB ingress rule from API
 resource "aws_vpc_security_group_ingress_rule" "allow-api-to-db" {
-  security_group_id = aws_db_instance.rds-db.id
+  security_group_id = aws_security_group.rds.id
 
   from_port                    = 5432
   ip_protocol                  = "tcp"
@@ -78,7 +78,7 @@ resource "aws_vpc_security_group_ingress_rule" "allow-api-to-db" {
 
 # DB egress rule to API
 resource "aws_vpc_security_group_egress_rule" "allow-db-to-api" {
-  security_group_id = aws_db_instance.rds-db.id
+  security_group_id = aws_security_group.rds.id
 
   from_port                    = 5432
   ip_protocol                  = "tcp"


### PR DESCRIPTION
Basic idea was to move API services and DB onto private subnet of same default VPC we have been using. Then use security groups to make sure that traffic only flows from Internet → ALB → API services → DB. ALB is only resource left in default public subnet. Only API services can talk to DB and DB can only talk to API services.  

Ran into issue with API services once we placed them on private subnet: containers had no access to internet so couldn't pull the container images from Docker Hub. Also prevented containers from talking to CloudWatch for logs and AWS Secrets Manager for secret environment variables. 

Fixed this by using a NAT gateway to route internet traffic from private subnet. Containers can send requests out, but inbound traffic through NAT and into private subnet is locked down and only allows responses to the containers's requests. 

The tradeoff here is [ cost of NAT ($0.04 per hour it's up, and $0.04 per GB of data transferred) ](https://aws.amazon.com/vpc/pricing/) and allowing private subnet to connect to internet (even though it's "one-way"). Alternative would be to use AWS PrivateLink to create interface VPC endpoints to connect to endpoint services (such as CloudWatch and AWS Secrets Manager). This version would be cheaper at [$0.01 per hour and $0.01 per GB transferred, per endpoint](https://aws.amazon.com/privatelink/pricing/), and if we used AWS Elastic Container Registry instead of Docker Hub to host our container images, we could eliminate the need for our private subnet to connect to the internet. All such container related configuration/provisioning/admin traffic could stay inside AWS. 

However, since we would need a minimum of 3 interface VPC endpoints, the price difference per hour between NAT ($0.04) or PrivateLink ($0.03) would be nominal. Data transfer rates for PrivateLink would remain cheaper.
A possible candidate for future work.