### PR TITLE
Subnets

### DIFF
--- a/instance/main.tf
+++ b/instance/main.tf
@@ -3,7 +3,7 @@ resource "aws_lb" "alb" {
   name               = "${var.project_name}-alb"
   internal           = false
   load_balancer_type = "application"
-  security_groups    = [aws_security_group.allow_all.id] # need to make SGs
+  security_groups    = [aws_security_group.alb_web_traffic.id]
   subnets            = [aws_default_subnet.default_subnet_a.id, aws_default_subnet.default_subnet_b.id]
 }
 
@@ -155,9 +155,9 @@ resource "aws_ecs_service" "api-service" {
   }
 
   network_configuration {
-    subnets          = [aws_default_subnet.default_subnet_a.id, aws_default_subnet.default_subnet_b.id]
-    assign_public_ip = true                              # Provide the containers with public IPs
-    security_groups  = [aws_security_group.allow_all.id] # Set up the security group
+    subnets          = [aws_subnet.private_subnet_a.id, aws_subnet.private_subnet_b.id]
+    assign_public_ip = false
+    security_groups  = [aws_security_group.api_servers.id]
   }
 }
 
@@ -177,9 +177,9 @@ resource "aws_ecs_service" "postgrest-service" {
   }
 
   network_configuration {
-    subnets          = [aws_default_subnet.default_subnet_a.id, aws_default_subnet.default_subnet_b.id]
-    assign_public_ip = true                              # Provide the containers with public IPs
-    security_groups  = [aws_security_group.allow_all.id] # Set up the security group
+    subnets          = [aws_subnet.private_subnet_a.id, aws_subnet.private_subnet_b.id]
+    assign_public_ip = false
+    security_groups  = [aws_security_group.api_servers.id]
   }
 }
 

--- a/instance/rds.tf
+++ b/instance/rds.tf
@@ -2,20 +2,22 @@
 resource "aws_db_instance" "rds-db" {
   allocated_storage      = 10
   apply_immediately      = true
-  db_name                = "postgres"
+  db_name                = "${var.project_name}_pg_db"
   engine                 = "postgres"
   engine_version         = "14"
   instance_class         = "db.t3.micro"
   parameter_group_name   = aws_db_parameter_group.rds.name
+  db_subnet_group_name   = aws_db_subnet_group.rds-postgres.id
   vpc_security_group_ids = [aws_security_group.rds.id]
   skip_final_snapshot    = true
   username               = data.aws_secretsmanager_secret_version.postgres_username_data.secret_string
   password               = data.aws_secretsmanager_secret_version.postgres_password_data.secret_string
+
 }
 
 # create parameter group for db
 resource "aws_db_parameter_group" "rds" {
-  name   = var.project_name
+  name   = "${var.project_name}-db-param-group"
   family = "postgres14"
 
   parameter {
@@ -24,25 +26,11 @@ resource "aws_db_parameter_group" "rds" {
   }
 }
 
-resource "aws_security_group" "rds" {
-  name   = "${var.project_name}_rds"
-  vpc_id = aws_default_vpc.default_vpc.id
-
-  ingress {
-    from_port   = 5432
-    to_port     = 5432
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  egress {
-    from_port   = 5432
-    to_port     = 5432
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
+resource "aws_db_subnet_group" "rds-postgres" {
+  name       = "${var.project_name}_rds_subnet_group"
+  subnet_ids = [aws_subnet.private_subnet_a.id, aws_subnet.private_subnet_b.id]
 
   tags = {
-    Name = "${var.project_name}_rds"
+    Name = "RDS-db-subnet-group"
   }
 }

--- a/instance/rds.tf
+++ b/instance/rds.tf
@@ -31,6 +31,6 @@ resource "aws_db_subnet_group" "rds-postgres" {
   subnet_ids = [aws_subnet.private_subnet_a.id, aws_subnet.private_subnet_b.id]
 
   tags = {
-    Name = "RDS-db-subnet-group"
+    Name = "${var.project_name}_rds"
   }
 }

--- a/instance/security-groups.tf
+++ b/instance/security-groups.tf
@@ -1,25 +1,102 @@
-# provision security groups
-resource "aws_security_group" "allow_all" {
+# provision security group for load balancer
+resource "aws_security_group" "alb_web_traffic" {
   name        = "lb_sg"
-  description = "testing out ingress and egress in tf "
+  description = "only allow http and https inbound. allow all outbound"
   vpc_id      = aws_default_vpc.default_vpc.id
   tags = {
-    Name = "openBothWays"
+    Name = "${var.project_name}_internet_facing_alb"
   }
 }
 
-# Ingress rule
-resource "aws_vpc_security_group_ingress_rule" "allow_all" {
-  security_group_id = aws_security_group.allow_all.id
+# lb Ingress rules
+resource "aws_vpc_security_group_ingress_rule" "http" {
+  security_group_id = aws_security_group.alb_web_traffic.id
+
+  cidr_ipv4   = "0.0.0.0/0"
+  from_port   = 80
+  ip_protocol = "tcp"
+  to_port     = 80
+}
+
+resource "aws_vpc_security_group_ingress_rule" "https" {
+  security_group_id = aws_security_group.alb_web_traffic.id
+
+  cidr_ipv4   = "0.0.0.0/0"
+  from_port   = 443
+  ip_protocol = "tcp"
+  to_port     = 443
+}
+
+# lb Egress rules
+resource "aws_vpc_security_group_egress_rule" "allow_all" {
+  security_group_id = aws_security_group.alb_web_traffic.id
 
   cidr_ipv4   = "0.0.0.0/0"
   ip_protocol = -1 #all protocols
 }
 
-# Egress rule
-resource "aws_vpc_security_group_egress_rule" "allow_all" {
-  security_group_id = aws_security_group.allow_all.id
+# API servers security group
+resource "aws_security_group" "api_servers" {
+  name        = "${var.project_name}_api_sg"
+  description = "only reachable from lb and db. NAT allows image pulls"
+  vpc_id      = aws_default_vpc.default_vpc.id
+  tags = {
+    Name = "${var.project_name}_api_sg"
+  }
+}
+
+# API ingress rule from alb
+resource "aws_vpc_security_group_ingress_rule" "alb-to-api" {
+  security_group_id = aws_security_group.api_servers.id
+
+  ip_protocol                  = -1
+  referenced_security_group_id = aws_security_group.alb_web_traffic.id
+}
+
+# API ingress rule from db
+resource "aws_vpc_security_group_ingress_rule" "db-to-api" {
+  security_group_id = aws_security_group.api_servers.id
+
+  from_port                    = 5432
+  ip_protocol                  = "tcp"
+  to_port                      = 5432
+  referenced_security_group_id = aws_security_group.rds.id
+}
+
+# API egress rule. Wide open to allow for image pulls. 
+resource "aws_vpc_security_group_egress_rule" "allow-all" {
+  security_group_id = aws_security_group.api_servers.id
 
   cidr_ipv4   = "0.0.0.0/0"
-  ip_protocol = -1 #all protocols
+  ip_protocol = -1
+}
+
+# DB security group
+resource "aws_security_group" "rds" {
+  name        = "${var.project_name}_rds"
+  vpc_id      = aws_default_vpc.default_vpc.id
+  description = "only reachable from api servers"
+  tags = {
+    Name = "${var.project_name}_rds"
+  }
+}
+
+# DB ingress rule from API
+resource "aws_vpc_security_group_ingress_rule" "allow-api-to-db" {
+  security_group_id = aws_security_group.rds.id
+
+  from_port                    = 5432
+  ip_protocol                  = "tcp"
+  to_port                      = 5432
+  referenced_security_group_id = aws_security_group.api_servers.id
+}
+
+# DB egress rule to API
+resource "aws_vpc_security_group_egress_rule" "allow-db-to-api" {
+  security_group_id = aws_security_group.rds.id
+
+  from_port                    = 5432
+  ip_protocol                  = "tcp"
+  to_port                      = 5432
+  referenced_security_group_id = aws_security_group.api_servers.id
 }

--- a/instance/vpc.tf
+++ b/instance/vpc.tf
@@ -1,7 +1,59 @@
-# VPC and private subnets
+# Default VPC
 resource "aws_default_vpc" "default_vpc" {}
 
-# Provide references to your default subnets
+# route table for private subnet
+resource "aws_route_table" "private" {
+  vpc_id = aws_default_vpc.default_vpc.id
+
+  route {
+    cidr_block = "172.31.0.0/16"
+    gateway_id = "local"
+  }
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_nat_gateway.nat.id
+  }
+}
+
+# private subnet a
+resource "aws_subnet" "private_subnet_a" {
+  cidr_block        = "172.31.253.0/24"
+  vpc_id            = aws_default_vpc.default_vpc.id
+  availability_zone = "${var.region}a"
+}
+
+#private subnet b
+resource "aws_subnet" "private_subnet_b" {
+  cidr_block        = "172.31.255.0/24"
+  vpc_id            = aws_default_vpc.default_vpc.id
+  availability_zone = "${var.region}b"
+}
+
+#associate private subnets with private route table
+resource "aws_route_table_association" "a" {
+  subnet_id      = aws_subnet.private_subnet_a.id
+  route_table_id = aws_route_table.private.id
+}
+
+resource "aws_route_table_association" "b" {
+  subnet_id      = aws_subnet.private_subnet_b.id
+  route_table_id = aws_route_table.private.id
+}
+
+# create elastic ip to be used by NAT
+resource "aws_eip" "nat" {
+  domain = "vpc"
+}
+
+#create NAT gateway
+resource "aws_nat_gateway" "nat" {
+  allocation_id = aws_eip.nat.id
+  subnet_id     = aws_default_subnet.default_subnet_a.id
+}
+
+
+# default public subnets
 resource "aws_default_subnet" "default_subnet_a" {
   availability_zone = "${var.region}a"
 }


### PR DESCRIPTION
Basic idea was to move API services and DB onto private subnet of same default VPC we have been using. Then, use security groups to make sure that traffic only flows from Internet → ALB → API services → DB. 

ALB is only resource left in default public subnet. Only API services can talk to DB and DB can only talk to API services.

Ran into issue with API services once we placed them on private subnet: containers had no access to internet so couldn't pull the container images from Docker Hub. Also prevented containers from talking to CloudWatch for logs and AWS Secrets Manager for secret environment variables.

Fixed this by using a NAT gateway to route internet traffic from private subnet. Containers can send requests out, but inbound traffic through NAT and into private subnet is locked down and only allows responses to the containers's requests.

The tradeoff here is [cost of NAT ($0.04 per hour, and $0.04 per GB of data transferred)](https://aws.amazon.com/vpc/pricing/) and allowing private subnet to connect to internet (even though it's "one-way"). Alternative would be to use AWS PrivateLink to create interface VPC endpoints to connect to endpoint services (such as CloudWatch and AWS Secrets Manager). This version would be cheaper at [$0.01 per hour and $0.01 per GB transferred, per endpoint](https://aws.amazon.com/privatelink/pricing/), and if we used AWS Elastic Container Registry instead of Docker Hub to host our container images, we could eliminate the need for our private subnet to connect to the internet. All such container related configuration/provisioning/admin traffic could stay inside AWS.

However, since we would need a minimum of 3 interface VPC endpoints, the price difference per hour between NAT ($0.04) or PrivateLink ($0.03) would be nominal. Data transfer rates for PrivateLink would remain cheaper.

A possible candidate for future work.