### PR TITLE
Debugging

### DIFF
--- a/admin_db/main.tf
+++ b/admin_db/main.tf
@@ -18,6 +18,6 @@ output "private_subnet_b_id" {
   value = aws_subnet.private_subnet_b.id
 }
 
-# terraform {
-#     backend "s3" {}
-# }
+terraform {
+  backend "s3" {}
+}

--- a/admin_db/main.tf
+++ b/admin_db/main.tf
@@ -18,6 +18,6 @@ output "private_subnet_b_id" {
   value = aws_subnet.private_subnet_b.id
 }
 
-terraform {
-    backend "s3" {}
-}
+# terraform {
+#     backend "s3" {}
+# }

--- a/admin_db/ssl.tf
+++ b/admin_db/ssl.tf
@@ -8,9 +8,9 @@ resource "aws_acm_certificate" "cert" {
   }
 }
 
-data "aws_route53_zone" "zone" {
-  name         = var.domain_name
-  private_zone = false
+resource "aws_route53_zone" "zone" {
+  name = var.domain_name
+  # private_zone = false
 }
 
 resource "aws_route53_record" "record" {
@@ -27,7 +27,7 @@ resource "aws_route53_record" "record" {
   records         = [each.value.record]
   ttl             = 60
   type            = each.value.type
-  zone_id         = data.aws_route53_zone.zone.zone_id
+  zone_id         = aws_route53_zone.zone.zone_id
 }
 
 resource "aws_acm_certificate_validation" "cert" {
@@ -36,5 +36,5 @@ resource "aws_acm_certificate_validation" "cert" {
 }
 
 output "aws_route53_zone_id" {
-  value = data.aws_route53_zone.zone.zone_id
+  value = aws_route53_zone.zone.zone_id
 }

--- a/admin_db/ssl.tf
+++ b/admin_db/ssl.tf
@@ -10,7 +10,7 @@ resource "aws_acm_certificate" "cert" {
 
 resource "aws_route53_zone" "zone" {
   name = var.domain_name
-  # private_zone = false
+  # private_zone = false  ## data resource has this property, but not actual resource
 }
 
 resource "aws_route53_record" "record" {

--- a/admin_db/ssl.tf
+++ b/admin_db/ssl.tf
@@ -8,9 +8,9 @@ resource "aws_acm_certificate" "cert" {
   }
 }
 
-resource "aws_route53_zone" "zone" {
-  name = var.domain_name
-  # private_zone = false  ## data resource has this property, but not actual resource
+data "aws_route53_zone" "zone" {
+  name         = var.domain_name
+  private_zone = false
 }
 
 resource "aws_route53_record" "record" {
@@ -27,7 +27,7 @@ resource "aws_route53_record" "record" {
   records         = [each.value.record]
   ttl             = 60
   type            = each.value.type
-  zone_id         = aws_route53_zone.zone.zone_id
+  zone_id         = data.aws_route53_zone.zone.zone_id
 }
 
 resource "aws_acm_certificate_validation" "cert" {
@@ -36,5 +36,5 @@ resource "aws_acm_certificate_validation" "cert" {
 }
 
 output "aws_route53_zone_id" {
-  value = aws_route53_zone.zone.zone_id
+  value = data.aws_route53_zone.zone.zone_id
 }

--- a/admin_db/variables.tf
+++ b/admin_db/variables.tf
@@ -5,11 +5,3 @@ variable "region" {
 variable "domain_name" {
   type = string
 }
-
-# variable "access_key" {
-#   type    = string
-# }
-
-# variable "secret_key" {
-#   type    = string
-# }

--- a/instance/main.tf
+++ b/instance/main.tf
@@ -91,7 +91,7 @@ resource "aws_lb_listener" "alb-listener-http" {
 }
 
 data "aws_acm_certificate" "cert" {
-  domain = "*.snowclone.xyz"
+  domain = "*.${var.domain_name}"
 }
 
 # Step 2: Configure the ALB listener with HTTPS

--- a/instance/main.tf
+++ b/instance/main.tf
@@ -197,6 +197,6 @@ output "app_url" {
   value = "${var.project_name}.${var.domain_name}"
 }
 
-# terraform {
-#   backend "s3" {}
-# }
+terraform {
+  backend "s3" {}
+}

--- a/instance/main.tf
+++ b/instance/main.tf
@@ -197,6 +197,6 @@ output "app_url" {
   value = "${var.project_name}.${var.domain_name}"
 }
 
-terraform {
-    backend "s3" {}
-}
+# terraform {
+#   backend "s3" {}
+# }

--- a/instance/rds.tf
+++ b/instance/rds.tf
@@ -10,8 +10,8 @@ resource "aws_db_instance" "rds-db" {
   db_subnet_group_name   = aws_db_subnet_group.rds-postgres.id
   vpc_security_group_ids = [aws_security_group.rds.id]
   skip_final_snapshot    = true
-  username               = data.aws_secretsmanager_secret_version.postgres_username_data.secret_string
-  password               = data.aws_secretsmanager_secret_version.postgres_password_data.secret_string
+  username               = aws_secretsmanager_secret_version.postgres_username_data.secret_string
+  password               = aws_secretsmanager_secret_version.postgres_password_data.secret_string
 
 }
 

--- a/instance/rds.tf
+++ b/instance/rds.tf
@@ -10,8 +10,8 @@ resource "aws_db_instance" "rds-db" {
   db_subnet_group_name   = aws_db_subnet_group.rds-postgres.id
   vpc_security_group_ids = [aws_security_group.rds.id]
   skip_final_snapshot    = true
-  username               = aws_secretsmanager_secret_version.postgres_username_data.secret_string
-  password               = aws_secretsmanager_secret_version.postgres_password_data.secret_string
+  username               = aws_secretsmanager_secret_version.postgres_username_secret_version.secret_string
+  password               = aws_secretsmanager_secret_version.postgres_password_secret_version.secret_string
 
 }
 

--- a/instance/secrets.tf
+++ b/instance/secrets.tf
@@ -1,5 +1,5 @@
 resource "aws_secretsmanager_secret" "postgres_username_secret" {
-  name = "${var.project_name}_postgres_username"
+  name                    = "${var.project_name}_postgres_username"
   recovery_window_in_days = 0
 }
 
@@ -8,14 +8,14 @@ resource "aws_secretsmanager_secret_version" "postgres_username_secret_version" 
   secret_string = var.postgres_username
 }
 
-data "aws_secretsmanager_secret_version" "postgres_username_data" {
-  secret_id = aws_secretsmanager_secret.postgres_username_secret.id
+# data "aws_secretsmanager_secret_version" "postgres_username_data" {
+#   secret_id = aws_secretsmanager_secret.postgres_username_secret.id
 
-  depends_on = [aws_secretsmanager_secret_version.postgres_username_secret_version]
-}
+#   depends_on = [aws_secretsmanager_secret_version.postgres_username_secret_version]
+# }
 
 resource "aws_secretsmanager_secret" "postgres_password_secret" {
-  name = "${var.project_name}_postgres_password"
+  name                    = "${var.project_name}_postgres_password"
   recovery_window_in_days = 0
 }
 
@@ -24,14 +24,14 @@ resource "aws_secretsmanager_secret_version" "postgres_password_secret_version" 
   secret_string = var.postgres_password
 }
 
-data "aws_secretsmanager_secret_version" "postgres_password_data" {
-  secret_id = aws_secretsmanager_secret.postgres_password_secret.id
+# data "aws_secretsmanager_secret_version" "postgres_password_data" {
+#   secret_id = aws_secretsmanager_secret.postgres_password_secret.id
 
-  depends_on = [aws_secretsmanager_secret_version.postgres_password_secret_version]
-}
+#   depends_on = [aws_secretsmanager_secret_version.postgres_password_secret_version]
+# }
 
 resource "aws_secretsmanager_secret" "api_token_secret" {
-  name = "${var.project_name}_api_token"
+  name                    = "${var.project_name}_api_token"
   recovery_window_in_days = 0
 }
 
@@ -40,14 +40,14 @@ resource "aws_secretsmanager_secret_version" "api_token_secret_version" {
   secret_string = var.api_token
 }
 
-data "aws_secretsmanager_secret_version" "api_token_data" {
-  secret_id = aws_secretsmanager_secret.api_token_secret.id
+# data "aws_secretsmanager_secret_version" "api_token_data" {
+#   secret_id = aws_secretsmanager_secret.api_token_secret.id
 
-  depends_on = [aws_secretsmanager_secret_version.api_token_secret_version]
-}
+#   depends_on = [aws_secretsmanager_secret_version.api_token_secret_version]
+# }
 
 resource "aws_secretsmanager_secret" "jwt_secret_secret" {
-  name = "${var.project_name}_jwt_secret"
+  name                    = "${var.project_name}_jwt_secret"
   recovery_window_in_days = 0
 }
 
@@ -56,8 +56,8 @@ resource "aws_secretsmanager_secret_version" "jwt_secret_secret_version" {
   secret_string = var.jwt_secret
 }
 
-data "aws_secretsmanager_secret_version" "jwt_secret_data" {
-  secret_id = aws_secretsmanager_secret.jwt_secret_secret.id
+# data "aws_secretsmanager_secret_version" "jwt_secret_data" {
+#   secret_id = aws_secretsmanager_secret.jwt_secret_secret.id
 
-  depends_on = [aws_secretsmanager_secret_version.jwt_secret_secret_version]
-}
+#   depends_on = [aws_secretsmanager_secret_version.jwt_secret_secret_version]
+# }

--- a/instance/secrets.tf
+++ b/instance/secrets.tf
@@ -8,12 +8,6 @@ resource "aws_secretsmanager_secret_version" "postgres_username_secret_version" 
   secret_string = var.postgres_username
 }
 
-# data "aws_secretsmanager_secret_version" "postgres_username_data" {
-#   secret_id = aws_secretsmanager_secret.postgres_username_secret.id
-
-#   depends_on = [aws_secretsmanager_secret_version.postgres_username_secret_version]
-# }
-
 resource "aws_secretsmanager_secret" "postgres_password_secret" {
   name                    = "${var.project_name}_postgres_password"
   recovery_window_in_days = 0
@@ -23,12 +17,6 @@ resource "aws_secretsmanager_secret_version" "postgres_password_secret_version" 
   secret_id     = aws_secretsmanager_secret.postgres_password_secret.id
   secret_string = var.postgres_password
 }
-
-# data "aws_secretsmanager_secret_version" "postgres_password_data" {
-#   secret_id = aws_secretsmanager_secret.postgres_password_secret.id
-
-#   depends_on = [aws_secretsmanager_secret_version.postgres_password_secret_version]
-# }
 
 resource "aws_secretsmanager_secret" "api_token_secret" {
   name                    = "${var.project_name}_api_token"
@@ -40,12 +28,6 @@ resource "aws_secretsmanager_secret_version" "api_token_secret_version" {
   secret_string = var.api_token
 }
 
-# data "aws_secretsmanager_secret_version" "api_token_data" {
-#   secret_id = aws_secretsmanager_secret.api_token_secret.id
-
-#   depends_on = [aws_secretsmanager_secret_version.api_token_secret_version]
-# }
-
 resource "aws_secretsmanager_secret" "jwt_secret_secret" {
   name                    = "${var.project_name}_jwt_secret"
   recovery_window_in_days = 0
@@ -55,9 +37,3 @@ resource "aws_secretsmanager_secret_version" "jwt_secret_secret_version" {
   secret_id     = aws_secretsmanager_secret.jwt_secret_secret.id
   secret_string = var.jwt_secret
 }
-
-# data "aws_secretsmanager_secret_version" "jwt_secret_data" {
-#   secret_id = aws_secretsmanager_secret.jwt_secret_secret.id
-
-#   depends_on = [aws_secretsmanager_secret_version.jwt_secret_secret_version]
-# }

--- a/instance/security-groups.tf
+++ b/instance/security-groups.tf
@@ -2,7 +2,7 @@
 resource "aws_security_group" "alb_web_traffic" {
   name        = "${var.project_name}_lb_sg"
   description = "only allow http and https inbound. allow all outbound"
-  vpc_id      = data.aws_vpc.default_vpc.id
+  vpc_id      = aws_default_vpc.default_vpc.id
   tags = {
     Name = "${var.project_name}_internet_facing_alb"
   }
@@ -39,7 +39,7 @@ resource "aws_vpc_security_group_egress_rule" "allow_all" {
 resource "aws_security_group" "api_servers" {
   name        = "${var.project_name}_api_sg"
   description = "only reachable from lb and db. NAT allows image pulls"
-  vpc_id      = data.aws_vpc.default_vpc.id
+  vpc_id      = aws_default_vpc.default_vpc.id
   tags = {
     Name = "${var.project_name}_api_sg"
   }
@@ -74,7 +74,7 @@ resource "aws_vpc_security_group_egress_rule" "allow-all" {
 # DB security group
 resource "aws_security_group" "rds" {
   name        = "${var.project_name}_rds"
-  vpc_id      = data.aws_vpc.default_vpc.id
+  vpc_id      = aws_default_vpc.default_vpc.id
   description = "only reachable from api servers"
   tags = {
     Name = "${var.project_name}_rds"

--- a/instance/task-definitions.tf
+++ b/instance/task-definitions.tf
@@ -21,11 +21,11 @@ resource "aws_ecs_task_definition" "api" {
       secrets = [
         {
           name      = "PG_USER"
-          valueFrom = data.aws_secretsmanager_secret_version.postgres_username_data.arn
+          valueFrom = aws_secretsmanager_secret_version.postgres_username_data.arn
         },
         {
           name      = "PG_PASSWORD"
-          valueFrom = data.aws_secretsmanager_secret_version.postgres_password_data.arn
+          valueFrom = aws_secretsmanager_secret_version.postgres_password_data.arn
         }
       ]
       environment = [
@@ -34,7 +34,7 @@ resource "aws_ecs_task_definition" "api" {
         { name = "PG_DATABASE", value = "postgres" }
       ]
       healthcheck = {
-        command     = ["CMD-SHELL", "curl http://localhost:8080/ || exit 1"], 
+        command     = ["CMD-SHELL", "curl http://localhost:8080/ || exit 1"],
         interval    = 5,
         timeout     = 5,
         startPeriod = 10,
@@ -62,15 +62,15 @@ resource "aws_ecs_task_definition" "api" {
       secrets = [
         {
           name      = "PG_USER"
-          valueFrom = data.aws_secretsmanager_secret_version.postgres_username_data.arn
+          valueFrom = aws_secretsmanager_secret_version.postgres_username_data.arn
         },
         {
           name      = "PG_PASSWORD"
-          valueFrom = data.aws_secretsmanager_secret_version.postgres_password_data.arn
+          valueFrom = aws_secretsmanager_secret_version.postgres_password_data.arn
         },
         {
           name      = "API_TOKEN"
-          valueFrom = data.aws_secretsmanager_secret_version.api_token_data.arn
+          valueFrom = aws_secretsmanager_secret_version.api_token_data.arn
         }
       ]
       environment = [
@@ -79,7 +79,7 @@ resource "aws_ecs_task_definition" "api" {
         { name = "PG_DATABASE", value = "postgres" }
       ]
       healthcheck = {
-        command     = ["CMD-SHELL", "curl http://localhost:5175/V1/api || exit 1"], 
+        command     = ["CMD-SHELL", "curl http://localhost:5175/V1/api || exit 1"],
         interval    = 5,
         timeout     = 5,
         startPeriod = 10,
@@ -120,7 +120,7 @@ resource "aws_ecs_task_definition" "postgrest" {
       secrets = [
         {
           name      = "PGRST_JWT_SECRET"
-          valueFrom = data.aws_secretsmanager_secret_version.jwt_secret_data.arn
+          valueFrom = aws_secretsmanager_secret_version.jwt_secret_data.arn
         }
       ]
       environment = [

--- a/instance/task-definitions.tf
+++ b/instance/task-definitions.tf
@@ -21,11 +21,11 @@ resource "aws_ecs_task_definition" "api" {
       secrets = [
         {
           name      = "PG_USER"
-          valueFrom = aws_secretsmanager_secret_version.postgres_username_data.arn
+          valueFrom = aws_secretsmanager_secret_version.postgres_username_secret_version.arn
         },
         {
           name      = "PG_PASSWORD"
-          valueFrom = aws_secretsmanager_secret_version.postgres_password_data.arn
+          valueFrom = aws_secretsmanager_secret_version.postgres_password_secret_version.arn
         }
       ]
       environment = [
@@ -62,15 +62,15 @@ resource "aws_ecs_task_definition" "api" {
       secrets = [
         {
           name      = "PG_USER"
-          valueFrom = aws_secretsmanager_secret_version.postgres_username_data.arn
+          valueFrom = aws_secretsmanager_secret_version.postgres_username_secret_version.arn
         },
         {
           name      = "PG_PASSWORD"
-          valueFrom = aws_secretsmanager_secret_version.postgres_password_data.arn
+          valueFrom = aws_secretsmanager_secret_version.postgres_password_secret_version.arn
         },
         {
           name      = "API_TOKEN"
-          valueFrom = aws_secretsmanager_secret_version.api_token_data.arn
+          valueFrom = aws_secretsmanager_secret_version.api_token_secret_version.arn
         }
       ]
       environment = [
@@ -120,7 +120,7 @@ resource "aws_ecs_task_definition" "postgrest" {
       secrets = [
         {
           name      = "PGRST_JWT_SECRET"
-          valueFrom = aws_secretsmanager_secret_version.jwt_secret_data.arn
+          valueFrom = aws_secretsmanager_secret_version.jwt_secret_secret_version.arn
         }
       ]
       environment = [

--- a/instance/task-roles.tf
+++ b/instance/task-roles.tf
@@ -17,10 +17,10 @@ resource "aws_iam_role_policy" "secret_access_policy" {
           "secretsmanager:DeleteSecret" // Added deletion permission
         ]
         Resource = [
-          data.aws_secretsmanager_secret_version.postgres_username_data.arn,
-          data.aws_secretsmanager_secret_version.postgres_password_data.arn,
-          data.aws_secretsmanager_secret_version.api_token_data.arn,
-          data.aws_secretsmanager_secret_version.jwt_secret_data.arn
+          aws_secretsmanager_secret_version.postgres_username_data.arn,
+          aws_secretsmanager_secret_version.postgres_password_data.arn,
+          aws_secretsmanager_secret_version.api_token_data.arn,
+          aws_secretsmanager_secret_version.jwt_secret_data.arn
         ]
       }
     ]

--- a/instance/task-roles.tf
+++ b/instance/task-roles.tf
@@ -17,10 +17,10 @@ resource "aws_iam_role_policy" "secret_access_policy" {
           "secretsmanager:DeleteSecret" // Added deletion permission
         ]
         Resource = [
-          aws_secretsmanager_secret_version.postgres_username_data.arn,
-          aws_secretsmanager_secret_version.postgres_password_data.arn,
-          aws_secretsmanager_secret_version.api_token_data.arn,
-          aws_secretsmanager_secret_version.jwt_secret_data.arn
+          aws_secretsmanager_secret_version.postgres_username_secret_version.arn,
+          aws_secretsmanager_secret_version.postgres_password_secret_version.arn,
+          aws_secretsmanager_secret_version.api_token_secret_version.arn,
+          aws_secretsmanager_secret_version.jwt_secret_secret_version.arn
         ]
       }
     ]


### PR DESCRIPTION
- refactored instance/ssl.tf to use resources instead of data resources for secrets
- replaced all references to these data resources with references to resource itself
- restored s3 backend resources for both admin_db and instance. (had commented out backend s3 resources in both admin_db and instance for local testing)

The above bug fixes allow new secrets to be created for each new backend instance spun up. The previous version encountered a bug when attemping to access and use the secrets via a terraform data resource. Since the secrets for the particular backend did not exist yet, the data resource would throw an error. A workaround was to run terraform apply a second time, which would work because the secrets had been created by the first run, and now the data resource could be accessed.

This fix eliminates the bug by creating new secrets each time an instance is spun up and referencing those newly created secrets throughout the terraform code.